### PR TITLE
Reactive Props V2

### DIFF
--- a/Basalt/libraries/utils.lua
+++ b/Basalt/libraries/utils.lua
@@ -3,7 +3,6 @@ local sub,find,reverse,rep,insert,len = string.sub,string.find,string.reverse,st
 
 local function splitString(str, delimiter)
     local results = {}
-    local nResults = 1
     if str == "" or delimiter == "" then
         return results
     end
@@ -11,12 +10,11 @@ local function splitString(str, delimiter)
     local delim_start, delim_end = find(str, delimiter, start)
         while delim_start do
             insert(results, sub(str, start, delim_start - 1))
-            nResults = nResults + 1
             start = delim_end + 1
             delim_start, delim_end = find(str, delimiter, start)
         end
     insert(results, sub(str, start))
-    return results, nResults
+    return results
 end
 
 local function removeTags(input)


### PR DESCRIPTION
The original reactive props system was based on a naive implementation (a hard-coded pattern match for the shared and props tables in a prop and a metatable to detect reads/writes on the shared table) that was proving difficult to extend further. This PR rebuilds the reaction system to be based on a new primitive, `basalt.reactive`, which is not coupled to the environment. It also does away with the naive pattern matching. Any global variable can now be accessed in a reactive prop. Additionally, reactive props are now **full Lua expressions**, which are computed to return a value. This makes it possible to do things like this:

```xml
<script>
  local basalt = require("basalt")
  getCount, setCount = basalt.reactive(0)
</script>

<button text={"Times clicked: " .. getCount()}>
  <onClick>
    setCount(getCount() + 1)
  </onClick>
</button>

<label text={"Times clicked * 2 = " .. getCount() * 2} />
```

Internally, this works in much the same way that Signals work in Solid.js. We populate a list of observers for a reactive value on the first pass render, based on calls to their respective get functions. A subsequent call of the set function will then update all these observers.

Other changes
- Removed the shared table, there's no need for it anymore
- Removed basalt from layout envs, because if it's needed it can just be imported. Unnecessary global variables are bad!
- Also removed the main variable from layouts loaded into a Frame