### PR TITLE
[XML] Untracked reactive value access

### DIFF
--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -207,10 +207,10 @@ return {
             end,
 
             untracked = function(getter)
-                local lastEffect = currentEffect
+                local prevEffect = currentEffect
                 currentEffect = nil
                 local value = getter()
-                currentEffect = lastEffect
+                currentEffect = prevEffect
                 return value
             end,
 
@@ -218,10 +218,10 @@ return {
                 local effect = {dependencies = {}}
                 local execute = function()
                     clearEffectDependencies(effect)
-                    local lastEffect = currentEffect
+                    local prevEffect = currentEffect
                     currentEffect = effect
                     effectFn()
-                    currentEffect = lastEffect
+                    currentEffect = prevEffect
                 end
                 effect.execute = execute
                 effect.execute()


### PR DESCRIPTION
Allows for accessing reactive values in an unreactive way, not updating after the first access. This by itself is not very useful but it can be used as a building block for more complex behaviour.

```xml
<script>
  basalt = require("basalt")
  getCount, setCount = basalt.reactive(0)
</script>

<button text={"Times clicked: " .. getCount()}>
  <onClick>
    setCount(getCount() + 1)
  </onClick>
</button>
<label text={"This value should never update: " .. basalt.untracked(getCount)} />
```