### PR TITLE
[XML] Child layouts

### DIFF
--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -183,6 +183,12 @@ end
 return {
     basalt = function(basalt)
         local object = {
+            layout = function(path)
+                return {
+                    path = path,
+                }
+            end,
+
             reactive = function(initialValue)
                 local value = initialValue
                 local observerEffects = {}


### PR DESCRIPTION
Allows loading of child layouts within another layout, which react to updates in their reactive props. Treat this as a proof of concept and just cementing the API, because the implementation will certainly change. Example:

layout.xml
```xml
<script>
  local basalt = require("basalt")
  AnotherLayout = basalt.layout("another_layout.xml")
  getText, setText = basalt.reactive("Button not clicked")
</script>

<AnotherLayout text={getText()} />
<button text="Click me">
  <onClick>
    setText("Button clicked")
  </onClick>
</button>
```

another_layout.xml
```xml
<label text={props.text} />
```