### PR TITLE
getProperty() and setProperty()

### DIFF
--- a/Basalt/objects/BaseFrame.lua
+++ b/Basalt/objects/BaseFrame.lua
@@ -46,7 +46,7 @@ return function(name, basalt)
         end,
 
         setXOffset = function(self, newXOffset)
-            return self:setOffset(newXOffset, yOffset)
+            return self:setOffset(newXOffset, nil)
         end,
 
         getYOffset = function(self)
@@ -54,7 +54,7 @@ return function(name, basalt)
         end,
 
         setYOffset = function(self, newYOffset)
-            return self:setOffset(xOffset, newYOffset)
+            return self:setOffset(nil, newYOffset)
         end,
 
         setPalette = function(self, col, ...)            

--- a/Basalt/objects/BaseFrame.lua
+++ b/Basalt/objects/BaseFrame.lua
@@ -41,6 +41,22 @@ return function(name, basalt)
             return self
         end,
 
+        getXOffset = function(self)
+            return xOffset
+        end,
+
+        setXOffset = function(self, newXOffset)
+            return self:setOffset(newXOffset, yOffset)
+        end,
+
+        getYOffset = function(self)
+            return yOffset
+        end,
+
+        setYOffset = function(self, newYOffset)
+            return self:setOffset(xOffset, newYOffset)
+        end,
+
         setPalette = function(self, col, ...)            
             if(self==basalt.getActiveFrame())then
                 if(type(col)=="string")then

--- a/Basalt/objects/Button.lua
+++ b/Basalt/objects/Button.lua
@@ -23,7 +23,11 @@ return function(name, basalt)
 
         getBase = function(self)
             return base
-        end,  
+        end,
+
+        getHorizontalAlign = function(self)
+            return textHorizontalAlign
+        end,
         
         setHorizontalAlign = function(self, pos)
             textHorizontalAlign = pos
@@ -31,10 +35,18 @@ return function(name, basalt)
             return self
         end,
 
+        getVerticalAlign = function(self)
+            return textVerticalAlign
+        end,
+
         setVerticalAlign = function(self, pos)
             textVerticalAlign = pos
             self:updateDraw()
             return self
+        end,
+
+        getText = function(self)
+            return text
         end,
 
         setText = function(self, newText)

--- a/Basalt/objects/Checkbox.lua
+++ b/Basalt/objects/Checkbox.lua
@@ -32,8 +32,24 @@ return function(name, basalt)
             return self
         end,
 
+        setActiveSymbol = function(self, sym)
+            return self:setSymbol(sym, nil)
+        end,
+
+        setInactiveSymbol = function(self, inactive)
+            return self:setSymbol(nil, inactive)
+        end,
+
         getSymbol = function(self)
             return symbol, inactiveSymbol
+        end,
+
+        getActiveSymbol = function(self)
+            return symbol
+        end,
+
+        getInactiveSymbol = function(self)
+            return inactiveSymbol
         end,
 
         setText = function(self, _text)
@@ -41,12 +57,22 @@ return function(name, basalt)
             return self
         end,
 
+        getText = function(self)
+            return text
+        end,
+
         setTextPosition = function(self, pos)
             textPos = pos or textPos
             return self
         end,
 
+        getTextPosition = function(self)
+            return textPos
+        end,
+
         setChecked = base.setValue,
+
+        getChecked = base.getValue,
 
         mouseHandler = function(self, button, x, y)
             if (base.mouseHandler(self, button, x, y)) then

--- a/Basalt/objects/Container.lua
+++ b/Basalt/objects/Container.lua
@@ -386,7 +386,7 @@ return function(name, basalt)
 
     for objectName, _ in pairs(basalt.getObjects()) do
         container["add" .. objectName] = function(self, id)
-            return addObject(self, basalt.createObject(objectName, id, basalt))
+            return addObject(self, basalt:createObject(objectName, id))
         end
     end
 

--- a/Basalt/objects/Dropdown.lua
+++ b/Basalt/objects/Dropdown.lua
@@ -83,8 +83,24 @@ return function(name, basalt)
             return self
         end,
 
+        setDropdownWidth = function(self, width)
+            return self:setDropdownSize(width, dropdownH)
+        end,
+
+        setDropdownHeight = function(self, height)
+            return self:setDropdownSize(dropdownW, height)
+        end,
+
         getDropdownSize = function(self)
             return dropdownW, dropdownH
+        end,
+
+        getDropdownWidth = function(self)
+            return dropdownW
+        end,
+
+        getDropdownHeight = function(self)
+            return dropdownH
         end,
 
         mouseHandler = function(self, button, x, y, isMon)

--- a/Basalt/objects/Flexbox.lua
+++ b/Basalt/objects/Flexbox.lua
@@ -76,6 +76,10 @@ return function(name, basalt)
             return spacing
         end,
 
+        getFlexDirection = function(self)
+            return flexDirection
+        end,
+
         setFlexDirection = function(self, direction)
             if direction == "row" or direction == "column" then
                 flexDirection = direction
@@ -84,12 +88,20 @@ return function(name, basalt)
             return self
         end,
 
+        getJustifyContent = function(self)
+            return justifyContent
+        end,
+
         setJustifyContent = function(self, alignment)
             if alignment == "flex-start" or alignment == "flex-end" or alignment == "center" or alignment == "space-between" or alignment == "space-around" then
                 justifyContent = alignment
                 applyLayout(self)
             end
             return self
+        end,
+
+        getAlignItems = function(self)
+            return alignItems
         end,
 
         setAlignItems = function(self, alignment)

--- a/Basalt/objects/Frame.lua
+++ b/Basalt/objects/Frame.lua
@@ -43,7 +43,7 @@ return function(name, basalt)
         end,
 
         setXOffset = function(self, newXOffset)
-            return self:setOffset(newXOffset, yOffset)
+            return self:setOffset(newXOffset, nil)
         end,
 
         getYOffset = function(self)
@@ -51,7 +51,7 @@ return function(name, basalt)
         end,
 
         setYOffset = function(self, newYOffset)
-            return self:setOffset(xOffset, newYOffset)
+            return self:setOffset(nil, newYOffset)
         end,
 
         setParent = function(self, p, ...)

--- a/Basalt/objects/Frame.lua
+++ b/Basalt/objects/Frame.lua
@@ -38,6 +38,22 @@ return function(name, basalt)
             return self
         end,
 
+        getXOffset = function(self)
+            return xOffset
+        end,
+
+        setXOffset = function(self, newXOffset)
+            return self:setOffset(newXOffset, yOffset)
+        end,
+
+        getYOffset = function(self)
+            return yOffset
+        end,
+
+        setYOffset = function(self, newYOffset)
+            return self:setOffset(xOffset, newYOffset)
+        end,
+
         setParent = function(self, p, ...)
             base.setParent(self, p, ...)
             parent = p

--- a/Basalt/objects/Graph.lua
+++ b/Basalt/objects/Graph.lua
@@ -32,8 +32,16 @@ return function(name, basalt)
             return self
         end,
 
+        setGraphSymbolColor = function(self, symbolColor)
+            return self:setGraphSymbolColor(nil, symbolColor)
+        end,
+
         getGraphSymbol = function(self)
             return graphSymbol, graphSymbolCol
+        end,
+
+        getGraphSymbolColor = function(self)
+            return graphSymbolCol
         end,
 
         addDataPoint = function(self, value)
@@ -73,6 +81,10 @@ return function(name, basalt)
                 self:updateDraw()
             end
             return self
+        end,
+
+        getGraphType = function(self)
+            return graphType
         end,
 
         setMaxEntries = function(self, value)

--- a/Basalt/objects/Image.lua
+++ b/Basalt/objects/Image.lua
@@ -73,6 +73,14 @@ return function(name, basalt)
             return self
         end,
 
+        setXOffset = function(self, _x)
+            return self:setOffset(self, _x, nil)
+        end,
+
+        setYOffset = function(self, _y)
+            return self:setOffset(self, nil, _y)
+        end,
+
         setSize = function(self, _x, _y)
             base:setSize(_x, _y)
             autoSize = false
@@ -81,6 +89,14 @@ return function(name, basalt)
 
         getOffset = function(self)
             return xOffset, yOffset
+        end,
+
+        getXOffset = function(self)
+            return xOffset
+        end,
+
+        getYOffset = function(self)
+            return yOffset
         end,
 
         selectFrame = function(self, id)
@@ -142,6 +158,10 @@ return function(name, basalt)
             return self
         end,
 
+        setPath = function(self, path)
+            return self:loadImage(path)
+        end,
+
         setImage = function(self, t)
             if(type(t)=="table")then
                 bimgLibrary = bimg(t)
@@ -176,6 +196,14 @@ return function(name, basalt)
             return self
         end,
 
+        getUsePalette = function(self)
+            return usePalette
+        end,
+
+        setUsePalette = function(self, use)
+            return self:usePalette(use)
+        end,
+
         play = function(self, inf)
             if(bimgLibrary.getMetadata("animated"))then
                 local t = bimgLibrary.getMetadata("duration") or bimgLibrary.getMetadata("secondsPerFrame") or 0.2
@@ -184,6 +212,10 @@ return function(name, basalt)
                 infinitePlay = inf or false
             end
             return self
+        end,
+
+        setPlay = function(self, inf)
+            return self:play(inf)
         end,
 
         stop = function(self)

--- a/Basalt/objects/Input.lua
+++ b/Basalt/objects/Input.lua
@@ -37,6 +37,14 @@ return function(name, basalt)
             return objectType==t or base.isType~=nil and base.isType(t) or false
         end,
 
+        setDefaultFG = function(self, fCol)
+            return self:setDefaultText(self, defaultText, fCol, nil)
+        end,
+
+        setDefaultBG = function(self, bCol)
+            return self:setDefaultText(self, defaultText, nil, bCol)
+        end,
+
         setDefaultText = function(self, text, fCol, bCol)
             defaultText = text
             defaultFGCol = fCol or defaultFGCol

--- a/Basalt/objects/Label.lua
+++ b/Basalt/objects/Label.lua
@@ -77,6 +77,12 @@ return function(name, basalt)
             return self
         end,
 
+        --- Gets the text alignment of the label.
+        --- @return string
+        getTextAlign = function(self)
+            return textAlign
+        end,
+
         --- Sets the text alignment of the label.
         --- @param align string  The alignment of the text. Can be "left", "center", or "right".
         --- @return object

--- a/Basalt/objects/List.lua
+++ b/Basalt/objects/List.lua
@@ -151,8 +151,24 @@ return function(name, basalt)
             return self
         end,
 
+        setSelectionBG = function(self, bgCol)
+            return self:setSelectionColor(bgCol, nil, selectionColorActive)
+        end,
+
+        setSelectionFG = function(self, fgCol)
+            return self:setSelectionColor(nil, fgCol, selectionColorActive)
+        end,
+
         getSelectionColor = function(self)
             return itemSelectedBG, itemSelectedFG
+        end,
+
+        getSelectionBG = function(self)
+            return itemSelectedBG
+        end,
+
+        getSelectionFG = function(self)
+            return itemSelectedFG
         end,
 
         isSelectionColorActive = function(self)
@@ -164,6 +180,10 @@ return function(name, basalt)
             if(scroll==nil)then scrollable = true end
             self:updateDraw()
             return self
+        end,
+
+        getScrollable = function(self)
+            return scrollable
         end,
 
         scrollHandler = function(self, dir, x, y)

--- a/Basalt/objects/Menubar.lua
+++ b/Basalt/objects/Menubar.lua
@@ -46,12 +46,19 @@ return function(name, basalt)
             return self
         end,
 
+        getSpace = function(self)
+            return space
+        end,
+
         setScrollable = function(self, scroll)
             scrollable = scroll
             if(scroll==nil)then scrollable = true end
             return self
         end,
 
+        getScrollable = function(self)
+            return scrollable
+        end,
 
         mouseHandler = function(self, button, x, y)
             if(base:getBase().mouseHandler(self, button, x, y))then

--- a/Basalt/objects/Object.lua
+++ b/Basalt/objects/Object.lua
@@ -33,7 +33,21 @@ return function(name, basalt)
         isType = function(self, t)
             return objectType==t
         end,
-        
+
+        getProperty = function(self, name)
+            local get = self["get" .. name:gsub("^%l", string.upper)]
+            if (get ~= nil) then
+                return get(self)
+            end
+        end,
+
+        setProperty = function(self, name, ...)
+            local set = self["set" .. name:gsub("^%l", string.upper)]
+            if (set ~= nil) then
+                return set(self, ...)
+            end
+        end,
+
         getName = function(self)
             return name
         end,

--- a/Basalt/objects/Program.lua
+++ b/Basalt/objects/Program.lua
@@ -479,6 +479,10 @@ return function(name, basalt)
             return self
         end;
 
+        setExecute = function(self, path, ...)
+            return self:execute(path, ...)
+        end,
+
         stop = function(self)            
             local parent = self:getParent()
             if (curProcess ~= nil) then

--- a/Basalt/objects/Progressbar.lua
+++ b/Basalt/objects/Progressbar.lua
@@ -25,6 +25,10 @@ return function(name, basalt)
             return self
         end,
 
+        getDirection = function(self)
+            return direction
+        end,
+
         setProgressBar = function(self, color, symbol, symbolcolor)
             activeBarColor = color or activeBarColor
             activeBarSymbol = symbol or activeBarSymbol
@@ -37,10 +41,38 @@ return function(name, basalt)
             return activeBarColor, activeBarSymbol, activeBarSymbolCol
         end,
 
+        setActiveBarColor = function(self, color)
+            return self:setProgressBar(color, nil, nil)
+        end,
+
+        getActiveBarColor = function(self)
+            return activeBarColor
+        end,
+
+        setActiveBarSymbol = function(self, symbol)
+            return self:setProgressBar(nil, symbol, nil)
+        end,
+
+        getActiveBarSymbol = function(self)
+            return activeBarSymbol
+        end,
+
+        setActiveBarSymbolColor = function(self, symbolColor)
+            return self:setProgressBar(nil, nil, symbolColor)
+        end,
+
+        getActiveBarSymbolColor = function(self)
+            return activeBarSymbolCol
+        end,
+
         setBackgroundSymbol = function(self, symbol)
             bgBarSymbol = symbol:sub(1, 1)
             self:updateDraw()
             return self
+        end,
+
+        getBackgroundSymbol = function(self)
+            return bgBarSymbol
         end,
 
         setProgress = function(self, value)

--- a/Basalt/objects/Radio.lua
+++ b/Basalt/objects/Radio.lua
@@ -53,8 +53,24 @@ return function(name, basalt)
             return self
         end,
 
+        setBoxSelectionBG = function(self, bg)
+            return self:setBoxSelectionColor(bg, boxSelectedFG)
+        end,
+
+        setBoxSelectionFG = function(self, fg)
+            return self:setBoxSelectionColor(boxSelectedBG, fg)
+        end,
+
         getBoxSelectionColor = function(self)
             return boxSelectedBG, boxSelectedFG
+        end,
+
+        getBoxSelectionBG = function(self)
+            return boxSelectedBG
+        end,
+
+        getBoxSelectionFG = function(self)
+            return boxSelectedFG
         end,
 
         setBoxDefaultColor = function(self, bg, fg)
@@ -63,8 +79,24 @@ return function(name, basalt)
             return self
         end,
 
+        setBoxDefaultBG = function(self, bg)
+            return self:setBoxDefaultColor(bg, boxNotSelectedFG)
+        end,
+
+        setBoxDefaultFG = function(self, fg)
+            return self:setBoxDefaultColor(boxNotSelectedBG, fg)
+        end,
+
         getBoxDefaultColor = function(self)
             return boxNotSelectedBG, boxNotSelectedFG
+        end,
+
+        getBoxDefaultBG = function(self)
+            return boxNotSelectedBG
+        end,
+
+        getBoxDefaultFG = function(self)
+            return boxNotSelectedFG
         end,
 
         mouseHandler = function(self, button, x, y, ...)

--- a/Basalt/objects/Scrollbar.lua
+++ b/Basalt/objects/Scrollbar.lua
@@ -62,6 +62,26 @@ return function(name, basalt)
             return self
         end,
 
+        setSymbolBG = function(self, bg)
+            return self:setSymbol(symbol, bg, nil)
+        end,
+
+        setSymbolFG = function(self, fg)
+            return self:setSymbol(symbol, nil, fg)
+        end,
+
+        getSymbol = function(self)
+            return symbol
+        end,
+
+        getSymbolBG = function(self)
+            return symbolBG
+        end,
+
+        getSymbolFG = function(self)
+            return symbolFG
+        end,
+
         setIndex = function(self, _index)
             index = _index
             if (index < 1) then
@@ -81,6 +101,10 @@ return function(name, basalt)
             return self
         end,
 
+        getScrollAmount = function(self)
+            return scrollAmount
+        end,
+
         getIndex = function(self)
             local w,h = self:getSize()
             return scrollAmount > (barType=="vertical" and h or w) and math.floor(scrollAmount/(barType=="vertical" and h or w) * index) or index
@@ -94,11 +118,19 @@ return function(name, basalt)
             return self
         end,
 
+        getSymbolSize = function(self)
+            return symbolSize
+        end,
+
         setBarType = function(self, _typ)
             barType = _typ:lower()
             updateSymbolSize()
             self:updateDraw()
             return self
+        end,
+
+        getBarType = function(self)
+            return barType
         end,
 
         mouseHandler = function(self, button, x, y, ...)

--- a/Basalt/objects/Slider.lua
+++ b/Basalt/objects/Slider.lua
@@ -46,6 +46,10 @@ return function(name, basalt)
             return self
         end,
 
+        getSymbol = function(self)
+            return symbol
+        end,
+
         setIndex = function(self, _index)
             index = _index
             if (index < 1) then
@@ -67,16 +71,28 @@ return function(name, basalt)
             return self
         end,
 
+        getMaxValue = function(self)
+            return maxValue
+        end,
+
         setSymbolColor = function(self, col)
             symbolColor = col
             self:updateDraw()
             return self
         end,
 
+        getSymbolColor = function(self)
+            return symbolColor
+        end,
+
         setBarType = function(self, _typ)
             barType = _typ:lower()
             self:updateDraw()
             return self
+        end,
+
+        getBarType = function(self)
+            return barType
         end,
 
         mouseHandler = function(self, button, x, y)

--- a/Basalt/objects/Switch.lua
+++ b/Basalt/objects/Switch.lua
@@ -20,14 +20,26 @@ return function(name, basalt)
             return self
         end,
 
+        getSymbol = function(self)
+            return bgSymbol
+        end,
+
         setActiveBackground = function(self, col)
             activeBG = col
             return self
         end,
 
+        getActiveBackground = function(self)
+            return activeBG
+        end,
+
         setInactiveBackground = function(self, col)
             inactiveBG = col
             return self
+        end,
+
+        getInactiveBackground = function(self)
+            return inactiveBG
         end,
 
 

--- a/Basalt/objects/Textfield.lua
+++ b/Basalt/objects/Textfield.lua
@@ -161,8 +161,24 @@ return function(name, basalt)
             return self
         end,
 
+        setSelectionFG = function(self, fg)
+            return self:setSelection(fg, nil)
+        end,
+
+        setSelectionBG = function(self, bg)
+            return self:setSelection(nil, bg)
+        end,
+
         getSelection = function(self)
             return selectionFG, selectionBG
+        end,
+
+        getSelectionFG = function(self)
+            return selectionFG
+        end,
+
+        getSelectionBG = function(self)
+            return selectionBG
         end,
 
         getLines = function(self)
@@ -287,6 +303,22 @@ return function(name, basalt)
             hIndex = yOff or hIndex
             self:updateDraw()
             return self
+        end,
+
+        getXOffset = function(self, xOff)
+            return wIndex
+        end,
+
+        setXOffset = function(self, xOff)
+            return self:setOffset(xOff, nil)
+        end,
+
+        getYOffset = function(self, xOff)
+            return hIndex
+        end,
+
+        setYOffset = function(self, yOff)
+            return self:setOffset(nil, yOff)
         end,
 
         getFocusHandler = function(self)

--- a/Basalt/objects/Timer.lua
+++ b/Basalt/objects/Timer.lua
@@ -19,6 +19,10 @@ return function(name, basalt)
             return self
         end,
 
+        getTime = function(self)
+            return timer
+        end,
+
         start = function(self)
             if(timerIsActive)then
                 os.cancelTimer(timerObj)
@@ -41,6 +45,14 @@ return function(name, basalt)
             timerIsActive = false
             self:removeEvent("other_event")
             return self
+        end,
+
+        setStart = function(self, start)
+            if (start == true) then
+                return self:start()
+            else
+                return self:cancel()
+            end
         end,
 
         onCall = function(self, func)

--- a/Basalt/objects/Treeview.lua
+++ b/Basalt/objects/Treeview.lua
@@ -157,13 +157,33 @@ return function(name, basalt)
             return self
         end,
 
+        setXOffset = function(self, x)
+            return self:setOffset(x, yOffset)
+        end,
+
+        setYOffset = function(self, y)
+            return self:setOffset(xOffset, y)
+        end,
+
         getOffset = function(self)
             return xOffset, yOffset
+        end,
+
+        getXOffset = function(self)
+            return xOffset
+        end,
+
+        getYOffset = function(self)
+            return yOffset
         end,
 
         setScrollable = function(self, scroll)
             scrollable = scroll
             return self
+        end,
+
+        getScrollable = function(self, scroll)
+            return scrollable
         end,
 
         setSelectionColor = function(self, bgCol, fgCol, active)
@@ -174,8 +194,24 @@ return function(name, basalt)
             return self
         end,
 
+        setSelectionBG = function(self, bgCol)
+            return self:setSelectionColor(bgCol, nil, selectionColorActive)
+        end,
+
+        setSelectionFG = function(self, fgCol)
+            return self:setSelectionColor(nil, fgCol, selectionColorActive)
+        end,
+
         getSelectionColor = function(self)
             return itemSelectedBG, itemSelectedFG
+        end,
+
+        getSelectionBG = function(self)
+            return itemSelectedBG
+        end,
+
+        getSelectionFG = function(self)
+            return itemSelectedFG
         end,
 
         isSelectionColorActive = function(self)

--- a/Basalt/objects/VisualObject.lua
+++ b/Basalt/objects/VisualObject.lua
@@ -138,8 +138,16 @@ return function(name, basalt)
             return x
         end,
 
+        setX = function(self, newX)
+            return self:setPosition(newX, y)
+        end,
+
         getY = function(self)
             return y
+        end,
+
+        setY = function(self, newY)
+            return self:setPosition(x, newY)
         end,
 
         getPosition = function(self)
@@ -167,8 +175,16 @@ return function(name, basalt)
             return height
         end,
 
+        setHeight = function(self, newHeight)
+            return self:setSize(width, newHeight)
+        end,
+
         getWidth = function(self)
             return width
+        end,
+
+        setWidth = function(self, newWidth)
+            return self:setSize(newWidth, height)
         end,
 
         getSize = function(self)

--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -801,11 +801,11 @@ return {
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
                     "maxEntries",
-                    "type",
+                    "graphType",
                     "minValue",
                     "maxValue",
-                    "symbol",
-                    "symbolColor"
+                    "graphSymbol",
+                    "graphSymbolColor"
                 })
                 if(data["item"]~=nil)then
                     local tab = data["item"]

--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -475,7 +475,7 @@ return {
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
                     "text",
-                    "align"
+                    "textAlign"
                 })
                 return self
             end,

--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -825,7 +825,6 @@ return {
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
-                    "space",
                     "scrollable",
                     "selectionBg",
                     "selectionFg",

--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -590,11 +590,11 @@ return {
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
                     "symbol",
-                    "symbolColor",
+                    "symbolBG",
+                    "symbolFG",
                     "symbolSize",
                     "scrollAmount",
                     "index",
-                    "maxValue",
                     "barType"
                 })
                 return self

--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -415,8 +415,8 @@ return {
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
-                    "layout",
-                    "xOffset"
+                    "xOffset",
+                    "yOffset"
                 })
                 return self
             end,
@@ -429,7 +429,6 @@ return {
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
-                    "layout",
                     "xOffset",
                     "yOffset"
                 })

--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -636,8 +636,8 @@ return {
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
-                    "bgSelection",
-                    "fgSelection",
+                    "selectionBG",
+                    "selectionFG",
                     "xOffset",
                     "yOffset"
                 })

--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -721,7 +721,7 @@ return {
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
-                    "align",
+                    "textAlign",
                     "offset",
                     "selectionBg",
                     "selectionFg",

--- a/Basalt/plugins/xml.lua
+++ b/Basalt/plugins/xml.lua
@@ -256,30 +256,11 @@ return {
     VisualObject = function(base, basalt)
 
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                local x, y = self:getPosition()
-                local w, h = self:getSize()
-                if (name == "x") then
-                    self:setPosition(value, y)
-                elseif (name == "y") then
-                    self:setPosition(x, value)
-                elseif (name == "width") then
-                    self:setSize(value, h)
-                elseif (name == "height") then
-                    self:setSize(w, value)
-                elseif (name == "background") then
-                    self:setBackground(colors[value])
-                elseif (name == "foreground") then
-                    self:setForeground(colors[value])
-                end
-            end,
-
             updateSpecifiedValuesByXMLData = function(self, data, valueNames)
                 for _, name in ipairs(valueNames) do
                     local value = xmlValue(name, data)
                     if (value ~= nil) then
-                        self:updateValue(name, value)
+                        self:setProperty(name, value)
                     end
                 end
             end,
@@ -289,7 +270,7 @@ return {
                 for prop, expression in pairs(data:reactiveProperties()) do
                     local update = function()
                         local value = load("return " .. expression, nil, "t", renderContext.env)()
-                        self:updateValue(prop, value)
+                        self:setProperty(prop, value)
                     end
                     basalt.effect(update)
                 end
@@ -326,14 +307,6 @@ return {
 
     ChangeableObject = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "value") then
-                    self:setValue(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -439,17 +412,6 @@ return {
 
     BaseFrame = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local _, yOffset = self:getOffset()
-                if (name == "layout") then
-                    self:setLayout(value)
-                elseif (name == "xOffset") then
-                    self:setOffset(value, yOffset)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -464,19 +426,6 @@ return {
 
     Frame = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local xOffset, yOffset = self:getOffset()
-                if (name == "layout") then
-                    self:setLayout(value)
-                elseif (name == "xOffset") then
-                    self:setOffset(value, yOffset)
-                elseif (name == "yOffset") then
-                    self:setOffset(xOffset, value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -492,20 +441,6 @@ return {
 
     Flexbox = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "flexDirection") then
-                    self:setFlexDirection(value)
-                elseif (name == "justifyContent") then
-                    self:setJustifyContent(value)
-                elseif (name == "alignItems") then
-                    self:setAlignItems(value)
-                elseif (name == "spacing") then
-                    self:setSpacing(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -522,18 +457,6 @@ return {
 
     Button = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "text") then
-                    self:setText(value)
-                elseif (name == "horizontalAlign") then
-                    self:setHorizontalAlign(value)
-                elseif (name == "verticalAlign") then
-                    self:setVerticalAlign(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -549,16 +472,6 @@ return {
 
     Label = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "text") then
-                    self:setText(value)
-                elseif (name == "align") then
-                    self:setAlign(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -573,27 +486,6 @@ return {
 
     Input = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local defaultText, defaultFG, defaultBG = self:getDefaultText()
-                if (name == "defaultText") then
-                    self:setDefaultText(value, defaultFG, defaultBG)
-                elseif (name == "defaultFG") then
-                    self:setDefaultText(defaultText, value, defaultBG)
-                elseif (name == "defaultBG") then
-                    self:setDefaultText(defaultText, defaultFG, value)
-                elseif (name == "offset") then
-                    self:setOffset(value)
-                elseif (name == "textOffset") then
-                    self:setTextOffset(value)
-                elseif (name == "text") then
-                    self:setText(value)
-                elseif (name == "inputLimit") then
-                    self:setInputLimit(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -613,23 +505,6 @@ return {
 
     Image = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local xOffset, yOffset = self:getOffset()
-                if (name == "xOffset") then
-                    self:setOffset(value, yOffset)
-                elseif (name == "yOffset") then
-                    self:setOffset(xOffset, value)
-                elseif (name == "path") then
-                    self:loadImage(value)
-                elseif (name == "usePalette") then
-                    self:usePalette(value)
-                elseif (name == "play") then
-                    self:play(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -647,23 +522,6 @@ return {
 
     Checkbox = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local activeSymbol, inactiveSymbol = self:getSymbol()
-                if (name == "text") then
-                    self:setText(value)
-                elseif (name == "checked") then
-                    self:setChecked(value)
-                elseif (name == "textPosition") then
-                    self:setTextPosition(value)
-                elseif (name == "activeSymbol") then
-                    self:setSymbol(value, inactiveSymbol)
-                elseif (name == "inactiveSymbol") then
-                    self:setSymbol(activeSymbol, value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -681,14 +539,6 @@ return {
 
     Program = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "execute") then
-                    self:execute(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -702,25 +552,6 @@ return {
 
     Progressbar = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local activeBarColor, activeBarSymbol, activeBarSymbolCol = self:getProgressBar()
-                if (name == "direction") then
-                    self:setDirection(value)
-                elseif (name == "activeBarColor") then
-                    self:setProgressBar(value, activeBarSymbol, activeBarSymbolCol)
-                elseif (name == "activeBarSymbol") then
-                    self:setProgressBar(activeBarColor, value, activeBarSymbolCol)
-                elseif (name == "activeBarSymbolColor") then
-                    self:setProgressBar(activeBarColor, activeBarSymbol, value)
-                elseif (name == "backgroundSymbol") then
-                    self:setBackgroundSymbol(value)
-                elseif (name == "progress") then
-                    self:setProgress(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -739,22 +570,6 @@ return {
 
     Slider = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "symbol") then
-                    self:setSymbol(value)
-                elseif (name == "symbolColor") then
-                    self:setSymbolColor(value)
-                elseif (name == "index") then
-                    self:setIndex(value)
-                elseif (name == "maxValue") then
-                    self:setMaxValue(value)
-                elseif (name == "barType") then
-                    self:setBarType(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -772,26 +587,6 @@ return {
 
     Scrollbar = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "symbol") then
-                    self:setSymbol(value)
-                elseif (name == "symbolColor") then
-                    self:setSymbolColor(value)
-                elseif (name == "symbolSize") then
-                    self:setSymbolSize(value)
-                elseif (name == "scrollAmount") then
-                    self:setScrollAmount(value)
-                elseif (name == "index") then
-                    self:setIndex(value)
-                elseif (name == "maxValue") then
-                    self:setMaxValue(value)
-                elseif (name == "barType") then
-                    self:setBarType(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -811,14 +606,6 @@ return {
 
     MonitorFrame = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "monitor") then
-                    self:setMonitor(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -832,18 +619,6 @@ return {
 
     Switch = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "symbol") then
-                    self:setSymbol(value)
-                elseif (name == "activeBackground") then
-                    self:setActiveBackground(value)
-                elseif (name == "inactiveBackground") then
-                    self:setInactiveBackground(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -859,22 +634,6 @@ return {
 
     Textfield = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local fgSel, bgSel = self:getSelection()
-                local xOffset, yOffset = self:getOffset()
-                if (name == "bgSelection") then
-                    self:setSelection(fgSel, value)
-                elseif (name == "fgSelection") then
-                    self:setSelection(value, bgSel)
-                elseif (name == "xOffset") then
-                    self:setOffset(value, yOffset)
-                elseif (name == "yOffset") then
-                    self:setOffset(xOffset, value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -943,16 +702,6 @@ return {
 
     Timer = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "start") then
-                    self:start(value)
-                elseif (name == "time") then
-                    self:setTime(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -970,23 +719,6 @@ return {
 
     List = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local selBg, selFg = self:getSelectionColor()
-                if (name == "align") then
-                    self:setTextAlign(value)
-                elseif (name == "offset") then
-                    self:setOffset(value)
-                elseif (name == "selectionBg") then
-                    self:setSelectionColor(value, selFg)
-                elseif (name == "selectionFg") then
-                    self:setSelectionColor(selBg, value)
-                elseif (name == "scrollable") then
-                    self:setScrollable(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -1014,17 +746,6 @@ return {
 
     Dropdown = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local w, h = self:getDropdownSize()
-                if (name == "dropdownWidth") then
-                    self:setDropdownSize(value, h)
-                elseif (name == "dropdownHeight") then
-                    self:setDropdownSize(w, value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -1039,22 +760,6 @@ return {
 
     Radio = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local selBg, selFg = self:getBoxSelectionColor()
-                local defBg, defFg = self:setBoxDefaultColor()
-                if (name == "selectionBg") then
-                    self:setBoxSelectionColor(value, selFg)
-                elseif (name == "selectionFg") then
-                    self:setBoxSelectionColor(selBg, value)
-                elseif (name == "defaultBg") then
-                    self:setBoxDefaultColor(value, defFg)
-                elseif (name == "defaultFg") then
-                    self:setBoxDefaultColor(defBg, value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -1079,16 +784,6 @@ return {
 
     Menubar = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                if (name == "space") then
-                    self:setSpace(value)
-                elseif (name == "scrollable") then
-                    self:setScrollable(value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -1103,25 +798,6 @@ return {
 
     Graph = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local symbol, symbolCol = self:getGraphSymbol()
-                if (name == "maxEntries") then
-                    self:setMaxEntries(value)
-                elseif (name == "type") then
-                    self:setType(value)
-                elseif (name == "minValue") then
-                    self:setMinValue(value)
-                elseif (name == "maxValue") then
-                    self:setMaxValue(value)
-                elseif (name == "symbol") then
-                    self:setGraphSymbol(value, symbolCol)
-                elseif (name == "symbolColor") then
-                    self:setGraphSymbol(symbol, value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {
@@ -1147,26 +823,6 @@ return {
 
     Treeview = function(base, basalt)
         local object = {
-            updateValue = function(self, name, value)
-                if (value == nil) then return end
-                base.updateValue(self, name, value)
-                local selBg, selFg = self:getSelectionColor()
-                local xOffset, yOffset = self:getOffset()
-                if (name == "space") then
-                    self:setSpace(value)
-                elseif (name == "scrollable") then
-                    self:setScrollable(value)
-                elseif (name == "selectionBg") then
-                    self:setSelectionColor(value, selFg)
-                elseif (name == "selectionFg") then
-                    self:setSelectionColor(selBg, value)
-                elseif (name == "xOffset") then
-                    self:setOffset(value, yOffset)
-                elseif (name == "yOffset") then
-                    self:setOffset(xOffset, value)
-                end
-            end,
-
             setValuesByXMLData = function(self, data, renderContext)
                 base.setValuesByXMLData(self, data, renderContext)
                 self:updateSpecifiedValuesByXMLData(data, {


### PR DESCRIPTION
Adds helper functions that, given a name, looks for a get<Name> or set<Name> function within that object and calls it. Very useful for the XML plugin where over 300 lines of code can now be deleted! I've also added new getter and setter functions for all the properties that the XML plugin supports at the moment.