### PR TITLE
Allow events to be registered on elements without parents

### DIFF
--- a/Basalt/objects/Container.lua
+++ b/Basalt/objects/Container.lua
@@ -59,6 +59,9 @@ return function(name, basalt)
         table.insert(elements, {element = element, zIndex = zIndex, objId = objId})
         sorted = false
         element:setParent(self, true)
+        for event, _ in pairs(element:getRegisteredEvents()) do
+            self:addEvent(event, element)
+        end
         if(element.init~=nil)then element:init() end
         if(element.load~=nil)then element:load() end
         if(element.draw~=nil)then element:draw() end
@@ -96,6 +99,7 @@ return function(name, basalt)
                 return true
             end
         end
+        self:removeEvents(element)
         sorted = false
     end
 

--- a/Basalt/objects/Object.lua
+++ b/Basalt/objects/Object.lua
@@ -13,6 +13,7 @@ return function(name, basalt)
     local isEnabled,initialized = true,false
 
     local eventSystem = basaltEvent()
+    local registeredEvents = {}
     local activeEvents = {}
 
     local parent
@@ -113,7 +114,6 @@ return function(name, basalt)
         remove = function(self)
             if (parent ~= nil) then
                 parent:removeObject(self)
-                parent:removeEvents(self)
             end
             self:updateDraw()
             return self
@@ -139,11 +139,19 @@ return function(name, basalt)
             return eventSystem
         end,
 
+        getRegisteredEvents = function(self)
+            return registeredEvents
+        end,
+
         registerEvent = function(self, event, func)
             if(parent~=nil)then
                 parent:addEvent(event, self)
             end
-            return eventSystem:registerEvent(event, func)
+            eventSystem:registerEvent(event, func)
+            if (registeredEvents[event] == nil) then
+                registeredEvents[event] = {}
+            end
+            table.insert(registeredEvents[event], func)
         end,
 
         removeEvent = function(self, event, index)
@@ -152,7 +160,13 @@ return function(name, basalt)
                     parent:removeEvent(event, self)
                 end
             end
-            return eventSystem:removeEvent(event, index)
+            eventSystem:removeEvent(event, index)
+            if (registeredEvents[event] ~= nil) then
+                table.remove(registeredEvents[event], index)
+                if (#registeredEvents[event] == 0) then
+                    registeredEvents[event] = nil
+                end
+            end
         end,
 
         eventHandler = function(self, event, ...)
@@ -262,7 +276,7 @@ return function(name, basalt)
             end
             return self
         end,
-        }
+    }
 
     object.__index = object
     return object


### PR DESCRIPTION
So that elements can be created detached from any parent, have events registered then have those events work correctly once the element is attached to a parent