### PR TITLE
Fix addObject() by renaming to addChild()

### DIFF
--- a/Basalt/main.lua
+++ b/Basalt/main.lua
@@ -74,12 +74,12 @@ local getObjects = function()
     return moddedObjects
 end
 
-local getObject = function(id)
-    return getObjects()[id]
+local getObject = function(objectName)
+    return getObjects()[objectName]
 end
 
-local createObject = function(self, objectName, id)
-    return getObject(objectName)(id, self)
+local createObject = function(basalt, objectName, id)
+    return getObject(objectName)(id, basalt)
 end
 
 local bInstance = {
@@ -436,6 +436,11 @@ basalt = {
 
     setVariable = setVariable,
     getVariable = getVariable,
+
+    getObjects = getObjects,
+    getObject = getObject,
+
+    createObject = createObject,
 
     setBaseTerm = function(_baseTerm)
         baseTerm = _baseTerm

--- a/Basalt/objects/BaseFrame.lua
+++ b/Basalt/objects/BaseFrame.lua
@@ -120,10 +120,10 @@ return function(name, basalt)
                 if(self:isVisible())then
                     if(updateRender)then
                         base.render(self)
-                        local objects = self:getObjects()
-                        for _, obj in ipairs(objects) do
-                            if (obj.element.render ~= nil) then
-                                obj.element:render()
+                        local children = self:getChildren()
+                        for _, child in ipairs(children) do
+                            if (child.element.render ~= nil) then
+                                child.element:render()
                             end
                         end
                         updateRender = false

--- a/Basalt/objects/Container.lua
+++ b/Basalt/objects/Container.lua
@@ -59,6 +59,9 @@ return function(name, basalt)
         table.insert(elements, {element = element, zIndex = zIndex, objId = objId})
         sorted = false
         element:setParent(self, true)
+        for event, _ in pairs(element:getRegisteredEvents()) do
+            self:addEvent(event, element)
+        end
         if(element.init~=nil)then element:init() end
         if(element.load~=nil)then element:load() end
         if(element.draw~=nil)then element:draw() end
@@ -96,6 +99,7 @@ return function(name, basalt)
                 return true
             end
         end
+        self:removeEvents(element)
         sorted = false
     end
 

--- a/Basalt/objects/Flexbox.lua
+++ b/Basalt/objects/Flexbox.lua
@@ -21,12 +21,12 @@ return function(name, basalt)
     end
 
     local function applyLayout(self)
-        local objects = self:getObjects()
-        local totalElements = #objects
+        local children = self:getChildren()
+        local totalChildren = #children
         local width, height = self:getSize()
-    
+
         local mainAxisTotalChildSize = 0
-        for _, obj in ipairs(objects) do
+        for _, obj in ipairs(children) do
             local objWidth, objHeight = obj.element:getSize()
             if flexDirection == "row" then
                 mainAxisTotalChildSize = mainAxisTotalChildSize + objWidth
@@ -34,15 +34,15 @@ return function(name, basalt)
                 mainAxisTotalChildSize = mainAxisTotalChildSize + objHeight
             end
         end
-        local mainAxisAvailableSpace = (flexDirection == "row" and width or height) - mainAxisTotalChildSize - (spacing * (totalElements - 1))
+        local mainAxisAvailableSpace = (flexDirection == "row" and width or height) - mainAxisTotalChildSize - (spacing * (totalChildren - 1))
         local justifyContentOffset = 1
         if justifyContent == "center" then
             justifyContentOffset = 1 + mainAxisAvailableSpace / 2
         elseif justifyContent == "flex-end" then
-            justifyContentOffset = 1 + mainAxisvailableSpace
+            justifyContentOffset = 1 + mainAxisAvailableSpace
         end
-    
-        for _, obj in ipairs(objects) do
+
+        for _, obj in ipairs(children) do
             local alignItemsOffset = getObjectOffAxisOffset(self, obj)
             if flexDirection == "row" then
                 obj.element:setPosition(justifyContentOffset, alignItemsOffset)
@@ -55,7 +55,7 @@ return function(name, basalt)
             end
         end
     end
-    
+
 
     local object = {
         getType = function()
@@ -71,7 +71,7 @@ return function(name, basalt)
             applyLayout(self)
             return self
         end,
-    
+
         getSpacing = function(self)
             return spacing
         end,

--- a/Basalt/objects/Frame.lua
+++ b/Basalt/objects/Frame.lua
@@ -64,10 +64,10 @@ return function(name, basalt)
             if(base.render~=nil)then
                 if(self:isVisible())then
                     base.render(self)
-                    local objects = self:getObjects()
-                    for _, obj in ipairs(objects) do
-                        if (obj.element.render ~= nil) then
-                            obj.element:render()
+                    local children = self:getChildren()
+                    for _, child in ipairs(children) do
+                        if (child.element.render ~= nil) then
+                            child.element:render()
                         end
                     end
                 end

--- a/Basalt/objects/Input.lua
+++ b/Basalt/objects/Input.lua
@@ -162,7 +162,7 @@ return function(name, basalt)
                         end
                     end
                     if (key == keys.enter) then
-                        parent:removeFocusedObject(self)
+                        parent:clearFocusedChild(self)
                     end
                     if (key == keys.right) then
                         local tLength = tostring(base.getValue()):len()
@@ -263,7 +263,7 @@ return function(name, basalt)
                     end
                 end
                 local parent = self:getParent()
-                parent:removeFocusedObject()
+                parent:clearFocusedChild()
             end
         end,
 

--- a/Basalt/objects/Object.lua
+++ b/Basalt/objects/Object.lua
@@ -13,6 +13,7 @@ return function(name, basalt)
     local isEnabled,initialized = true,false
 
     local eventSystem = basaltEvent()
+    local registeredEvents = {}
     local activeEvents = {}
 
     local parent
@@ -113,7 +114,6 @@ return function(name, basalt)
         remove = function(self)
             if (parent ~= nil) then
                 parent:removeObject(self)
-                parent:removeEvents(self)
             end
             self:updateDraw()
             return self
@@ -139,11 +139,19 @@ return function(name, basalt)
             return eventSystem
         end,
 
+        getRegisteredEvents = function(self)
+            return registeredEvents
+        end,
+
         registerEvent = function(self, event, func)
             if(parent~=nil)then
                 parent:addEvent(event, self)
             end
-            return eventSystem:registerEvent(event, func)
+            eventSystem:registerEvent(event, func)
+            if (registeredEvents[event] == nil) then
+                registeredEvents[event] = {}
+            end
+            table.insert(registeredEvents[event], func)
         end,
 
         removeEvent = function(self, event, index)
@@ -152,7 +160,13 @@ return function(name, basalt)
                     parent:removeEvent(event, self)
                 end
             end
-            return eventSystem:removeEvent(event, index)
+            eventSystem:removeEvent(event, index)
+            if (registeredEvents[event] ~= nil) then
+                table.remove(registeredEvents[event], index)
+                if (#registeredEvents[event] == 0) then
+                    registeredEvents[event] = nil
+                end
+            end
         end,
 
         eventHandler = function(self, event, ...)
@@ -262,7 +276,7 @@ return function(name, basalt)
             end
             return self
         end,
-        }
+    }
 
     object.__index = object
     return object

--- a/Basalt/objects/Object.lua
+++ b/Basalt/objects/Object.lua
@@ -61,7 +61,7 @@ return function(name, basalt)
             if(noRemove)then parent = newParent return self end
             if (newParent.getType ~= nil and newParent:isType("Container")) then
                 self:remove()
-                newParent:addObject(self)
+                newParent:addChild(self)
                 if (self.show) then
                     self:show()
                 end
@@ -113,7 +113,7 @@ return function(name, basalt)
 
         remove = function(self)
             if (parent ~= nil) then
-                parent:removeObject(self)
+                parent:removeChild(self)
             end
             self:updateDraw()
             return self

--- a/Basalt/objects/ScrollableFrame.lua
+++ b/Basalt/objects/ScrollableFrame.lua
@@ -11,8 +11,8 @@ return function(name, basalt)
 
     local function getHorizontalScrollAmount(self)
         local amount = 0
-        local objects = self:getObjects()
-        for _, b in pairs(objects) do
+        local children = self:getChildren()
+        for _, b in pairs(children) do
             if(b.element.getWidth~=nil)and(b.element.getX~=nil)then
                 local w, x = b.element:getWidth(), b.element:getX()
                 local width = self:getWidth()
@@ -35,8 +35,8 @@ return function(name, basalt)
 
     local function getVerticalScrollAmount(self)
         local amount = 0
-        local objects = self:getObjects()
-        for _, b in pairs(objects) do
+        local children = self:getChildren()
+        for _, b in pairs(children) do
             if(b.element.getHeight~=nil)and(b.element.getY~=nil)then
                 local h, y = b.element:getHeight(), b.element:getY()
                 local height = self:getHeight()
@@ -106,7 +106,7 @@ return function(name, basalt)
 
         scrollHandler = function(self, dir, x, y)
             if(base:getBase().scrollHandler(self, dir, x, y))then
-                self:sortElementOrder()
+                self:sortChildren()
                 for _, obj in ipairs(self:getEvents("mouse_scroll")) do
                     if (obj.element.scrollHandler ~= nil) then
                         local xO, yO = 0, 0
@@ -122,7 +122,7 @@ return function(name, basalt)
                     end
                 end
                 scrollHandler(self, dir, x, y)
-                self:removeFocusedObject()
+                self:clearFocusedChild()
                 return true
             end
         end,

--- a/Basalt/objects/VisualObject.lua
+++ b/Basalt/objects/VisualObject.lua
@@ -3,7 +3,7 @@ local tHex = require("tHex")
 
 local sub, find, insert = string.sub, string.find, table.insert
 
-return function(name, basalt)   
+return function(name, basalt)
     local base = basalt.getObject("Object")(name, basalt)
     -- Base object
     local objectType = "VisualObject" -- not changeable
@@ -94,7 +94,7 @@ return function(name, basalt)
 
         setFocus = function(self)
             if (parent ~= nil) then
-                parent:setFocusedObject(self)
+                parent:setFocusedChild(self)
             end
             return self
         end,
@@ -312,7 +312,7 @@ return function(name, basalt)
                 local val = self:sendEvent("mouse_click", button, x - (objX-1), y - (objY-1), x, y, isMon)
                 if(val==false)then return false end
                 if(parent~=nil)then
-                    parent:setFocusedObject(self)
+                    parent:setFocusedChild(self)
                 end
                 isClicked = true
                 isDragging = true
@@ -343,7 +343,7 @@ return function(name, basalt)
                 dragStartX, dragStartY = x, y 
                 if(val~=nil)then return val end
                 if(parent~=nil)then
-                    parent:setFocusedObject(self)
+                    parent:setFocusedChild(self)
                 end
                 return true
             end
@@ -361,7 +361,7 @@ return function(name, basalt)
                 local val = self:sendEvent("mouse_scroll", dir, x - (objX-1), y - (objY-1))
                 if(val==false)then return false end
                 if(parent~=nil)then
-                    parent:setFocusedObject(self)
+                    parent:setFocusedChild(self)
                 end
                 return true
             end


### PR DESCRIPTION
addObject() wasn't working because Container has add methods for all object types, of which Object is one of them. This overrides the other addObject(), which funnily enough also depends on the original addObject().

It makes sense to rename addObject() to addChild(), as well as all other child-related functions, to avoid confusion.