### PR TITLE
Refactor reactive framework

### DIFF
--- a/Basalt/libraries/xmlParser.lua
+++ b/Basalt/libraries/xmlParser.lua
@@ -70,7 +70,7 @@ local XMLParser = {
         if #stack > 1 then
             error("XMLParser: unclosed " .. stack[#stack].tag)
         end
-        return top
+        return top.children
     end
 }
 

--- a/Basalt/objects/Container.lua
+++ b/Basalt/objects/Container.lua
@@ -73,11 +73,15 @@ return function(name, basalt)
         for event, _ in pairs(element:getRegisteredEvents()) do
             self:addEvent(event, element)
         end
-
-        if(element.init~=nil)then element:init() end
-        if(element.load~=nil)then element:load() end
-        if(element.draw~=nil)then element:draw() end
-
+        if (element.init~=nil) then
+            element:init()
+        end
+        if (element.load~=nil) then
+            element:load()
+        end
+        if (element.draw~=nil) then
+            element:draw()
+        end
         return element
     end
 

--- a/Basalt/plugins/reactive.lua
+++ b/Basalt/plugins/reactive.lua
@@ -173,6 +173,9 @@ return {
     Container = function(base, basalt)
         local object = {
             loadLayout = function(self, path, props)
+                if (props == nil) then
+                    props = {}
+                end
                 local layout = basalt.layout(path)
                 local objects = basalt.createObjectsFromLayout(layout, props)
                 for _, object in ipairs(objects) do

--- a/Basalt/plugins/reactive.lua
+++ b/Basalt/plugins/reactive.lua
@@ -127,7 +127,8 @@ return {
                     })
                     objects = basalt.createObjectsFromLayout(layout, props)
                 else
-                    local object = basalt:createObject(node.tag, node.attributes["id"])
+                    local objectName = node.tag:gsub("^%l", string.upper)
+                    local object = basalt:createObject(objectName, node.attributes["id"])
                     for attribute, expression in pairs(node.attributes) do
                         if (attribute:sub(1, 2) == "on") then
                             registerFunctionEvent(object, object[attribute], expression .. "()", env)


### PR DESCRIPTION
Removed most object-specific extensions in order to produce a more agnostic framework.

Also allows for reactive props to be passed to loadLayout() in imperative code, as long as they're wrapped in functions.

Also removes most specific event registration functions in favour of a generic one that looks for properties starting with "on". It would be worth having another look at this in future to determine a better way, but for now this avoids needing to hard code for each object.