### PR TITLE
Fix unrefactored old basalt.reactive calls, move reactive outside basalt

### DIFF
--- a/Basalt/plugins/reactive.lua
+++ b/Basalt/plugins/reactive.lua
@@ -1,5 +1,72 @@
 local XMLParser = require("xmlParser")
 
+local Reactive = {}
+
+Reactive.currentEffect = nil
+
+Reactive.observable = function(initialValue)
+    local value = initialValue
+    local observerEffects = {}
+    local get = function()
+        if (Reactive.currentEffect ~= nil) then
+            table.insert(observerEffects, Reactive.currentEffect)
+            table.insert(Reactive.currentEffect.dependencies, observerEffects)
+        end
+        return value
+    end
+    local set = function(newValue)
+        value = newValue
+        local observerEffectsCopy = {}
+        for index, effect in ipairs(observerEffects) do
+            observerEffectsCopy[index] = effect
+        end
+        for _, effect in ipairs(observerEffectsCopy) do
+            effect.execute()
+        end
+    end
+    return get, set
+end
+
+Reactive.untracked = function(getter)
+    local parentEffect = Reactive.currentEffect
+    Reactive.currentEffect = nil
+    local value = getter()
+    Reactive.currentEffect = parentEffect
+    return value
+end
+
+Reactive.effect = function(effectFn)
+    local effect = {dependencies = {}}
+    local execute = function()
+        Reactive.clearEffectDependencies(effect)
+        local parentEffect = Reactive.currentEffect
+        Reactive.currentEffect = effect
+        effectFn()
+        Reactive.currentEffect = parentEffect
+    end
+    effect.execute = execute
+    effect.execute()
+end
+
+Reactive.derived = function(computeFn)
+    local getValue, setValue = Reactive.observable();
+    Reactive.effect(function()
+        setValue(computeFn())
+    end)
+    return getValue;
+end
+
+Reactive.clearEffectDependencies = function(effect)
+    for _, dependency in ipairs(effect.dependencies) do
+        for index, backlink in ipairs(dependency) do
+            if (backlink == effect) then
+                table.remove(dependency, index)
+            end
+        end
+    end
+    effect.dependencies = {};
+end
+
 local Layout = {
     fromXML = function(text)
         local nodes = XMLParser.parseText(text)
@@ -29,19 +96,6 @@ local registerFunctionEvent = function(object, event, script, env)
             error("XML Error: "..msg)
         end
     end)
-end
-
-local currentEffect = nil
-
-local clearEffectDependencies = function(effect)
-    for _, dependency in ipairs(effect.dependencies) do
-        for index, backlink in ipairs(dependency) do
-            if (backlink == effect) then
-                table.remove(dependency, index)
-            end
-        end
-    end
-    effect.dependencies = {};
 end
 
 return {
@@ -79,57 +133,10 @@ return {
         end
 
         local object = {
-            observable = function(initialValue)
-                local value = initialValue
-                local observerEffects = {}
-                local get = function()
-                    if (currentEffect ~= nil) then
-                        table.insert(observerEffects, currentEffect)
-                        table.insert(currentEffect.dependencies, observerEffects)
-                    end
-                    return value
-                end
-                local set = function(newValue)
-                    value = newValue
-                    local observerEffectsCopy = {}
-                    for index, effect in ipairs(observerEffects) do
-                        observerEffectsCopy[index] = effect
-                    end
-                    for _, effect in ipairs(observerEffectsCopy) do
-                        effect.execute()
-                    end
-                end
-                return get, set
-            end,
-
-            untracked = function(getter)
-                local parentEffect = currentEffect
-                currentEffect = nil
-                local value = getter()
-                currentEffect = parentEffect
-                return value
-            end,
-
-            effect = function(effectFn)
-                local effect = {dependencies = {}}
-                local execute = function()
-                    clearEffectDependencies(effect)
-                    local parentEffect = currentEffect
-                    currentEffect = effect
-                    effectFn()
-                    currentEffect = parentEffect
-                end
-                effect.execute = execute
-                effect.execute()
-            end,
-
-            derived = function(computeFn)
-                local getValue, setValue = basalt.reactive();
-                basalt.effect(function()
-                    setValue(computeFn())
-                end)
-                return getValue;
-            end,
+            observable = Reactive.observable,
+            untracked = Reactive.untracked,
+            effect = Reactive.effect,
+            derived = Reactive.derived,
 
             layout = function(path)
                 if (not fs.exists(path)) then


### PR DESCRIPTION
Forgot to change a few instances of basalt.reactive calls to basalt.observable, which was breaking things

I'm also moving the core reactive system outside of the basalt object as i'd like for it to eventually become it's own independent library. It's capabilities are not limited to just the XML framework and it could potentially be used elsewhere.