### PR TITLE
Updated links on the site not to point to 404.

### DIFF
--- a/docs/docs1_6/objects/Basalt/setTheme.md
+++ b/docs/docs1_6/objects/Basalt/setTheme.md
@@ -2,11 +2,11 @@
 
 ## setTheme
 
-Sets the base theme of the project! Make sure to cover all existing objects, otherwise it will result in errors. A good example is [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/theme.lua). The theme can also be gotten with [`basalt.getTheme()`](objects/Basalt/getTheme)
+Sets the base theme of the project! Make sure to cover all existing objects, otherwise it will result in errors. A good example is [theme](https://github.com/Pyroxenium/Basalt/blob/bb1b1beb795e3cf06a84ca79408244bca715961e/Basalt/theme.lua). The theme can also be gotten with [`basalt.getTheme()`](objects/Basalt/getTheme)
 
 ### Parameters
 
-1. `table` theme layout look into [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/theme.lua) for a example
+1. `table` theme layout look into [theme](https://github.com/Pyroxenium/Basalt/blob/bb1b1beb795e3cf06a84ca79408244bca715961e/Basalt/theme.lua) for a example
 
 ### Usage
 

--- a/docs/docs1_6/objects/Frame/setTheme.md
+++ b/docs/docs1_6/objects/Frame/setTheme.md
@@ -1,10 +1,10 @@
 ## setTheme
 
-Sets the default theme, of that frame children objects always try to get the theme of its parent frame, if it does not exist it goes to its parent parent frame, and so on until it reaches the basalt manager's theme - which is stored in theme.lua (Please checkout [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/theme.lua) for how it could look like.
+Sets the default theme, of that frame children objects always try to get the theme of its parent frame, if it does not exist it goes to its parent parent frame, and so on until it reaches the basalt manager's theme - which is stored in theme.lua (Please checkout [theme](https://github.com/Pyroxenium/Basalt/blob/bb1b1beb795e3cf06a84ca79408244bca715961e/Basalt/theme.lua) for how it could look like.
 
 #### Parameters:
 
-1. `table` theme layout look into [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/theme.lua) for a example
+1. `table` theme layout look into [theme](https://github.com/Pyroxenium/Basalt/blob/bb1b1beb795e3cf06a84ca79408244bca715961e/Basalt/theme.lua) for a example
 
 #### Returns:
 

--- a/docs/objects/Basalt/setTheme.md
+++ b/docs/objects/Basalt/setTheme.md
@@ -2,11 +2,11 @@
 
 ### Description
 
-Sets the base theme of the project! Make sure to cover all existing objects, otherwise it will result in errors. A good example is [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/theme.lua). The theme can also be retrieved with [`basalt.getTheme()`](objects/Basalt/getTheme)
+Sets the base theme of the project! Make sure to cover all existing objects, otherwise it will result in errors. A good example is [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/plugins/themes.lua). The theme can also be retrieved with [`basalt.getTheme()`](objects/Basalt/getTheme)
 
 ### Parameters
 
-1. `table` theme - A table containing the theme layout. Look into [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/theme.lua) for an example
+1. `table` theme - A table containing the theme layout. Look into [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/plugins/themes.lua) for an example
 
 ### Usage
 

--- a/docs/objects/Frame/setTheme.md
+++ b/docs/objects/Frame/setTheme.md
@@ -1,10 +1,10 @@
 ## setTheme
 
-Sets the default theme, of that frame children objects always try to get the theme of its parent frame, if it does not exist it goes to its parent parent frame, and so on until it reaches the basalt manager's theme - which is stored in theme.lua (Please checkout [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/theme.lua) for how it could look like.
+Sets the default theme, of that frame children objects always try to get the theme of its parent frame, if it does not exist it goes to its parent parent frame, and so on until it reaches the basalt manager's theme - which is stored in theme.lua (Please checkout [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/plugins/themes.lua) for how it could look like.
 
 #### Parameters:
 
-1. `table` theme layout look into [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/theme.lua) for a example
+1. `table` theme layout look into [theme](https://github.com/Pyroxenium/Basalt/blob/master/Basalt/plugins/themes.lua) for a example
 
 #### Returns:
 


### PR DESCRIPTION
With 1.7 `Basalt/theme.lua` got moved to `Basalt/plugins/themes.lua`. Changed it to point there.
In 1.6 that file is in the original place, so changed it to link there. Before the changes it returned 404 on both places.