### PR TITLE
Use getter instead of accessing attribute in `basalt.getFrame`

### DIFF
--- a/Basalt/main.lua
+++ b/Basalt/main.lua
@@ -523,7 +523,7 @@ basalt = {
     
     getFrame = function(name)
         for _, value in pairs(frames) do
-            if (value.name == name) then
+            if (value.getName() == name) then
                 return value
             end
         end


### PR DESCRIPTION
`name` is not an exported attribute of the Object table, so this always returned nil, failing all comparisons.